### PR TITLE
update most-subject to work with most 0.18.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "eslint-plugin-cycle": "^1.0.2",
     "eslint-plugin-no-class": "^0.1.0",
     "mocha": "^2.4.5",
-    "most": "^0.18.1"
+    "most": "^0.18.6",
+    "@most/multicast": "^1.0.3"
   },
   "peerDependencies": {
     "most": "*"

--- a/src/Replay.js
+++ b/src/Replay.js
@@ -1,5 +1,5 @@
 import {Stream} from 'most'
-import MulticastSource from 'most/lib/source/MulticastSource'
+import {MulticastSource} from '@most/multicast'
 
 function pushEvents(sink, buffer) {
   let i = 0

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import {Stream} from 'most'
-import MulticastSource from 'most/lib/source/MulticastSource'
+import {MulticastSource} from '@most/multicast'
 import {Observer} from './Observer'
 import {replay} from './Replay'
 


### PR DESCRIPTION
As `most` has changed the way it loads `multicast` this library needs to depend on `@most/multicast` too.