### PR TITLE
fix @most/multicast dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "url": "https://github.com/tylors/most-subject/issues"
   },
   "homepage": "https://github.com/tylors/most-subject#readme",
+  "dependencies": {
+    "@most/multicast": "^1.0.3"
+  },
   "devDependencies": {
     "assert": "^1.3.0",
     "babel-cli": "^6.5.1",
@@ -36,8 +39,7 @@
     "eslint-plugin-cycle": "^1.0.2",
     "eslint-plugin-no-class": "^0.1.0",
     "mocha": "^2.4.5",
-    "most": "^0.18.6",
-    "@most/multicast": "^1.0.3"
+    "most": "^0.18.6"
   },
   "peerDependencies": {
     "most": "*"


### PR DESCRIPTION
Sorry @TylorS! My last PR did not fix the issue as I added `@most/multicast` to `devDependencies`. This PR fixes this.