### PR TITLE
Add rollup dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "babel-plugin-syntax-flow": "^6.8.0",
     "babel-plugin-transform-flow-strip-types": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
+    "babel-preset-es2015-rollup": "^1.1.1",
     "documentation": "^4.0.0-beta2",
     "eslint": "^2.10.1",
     "flow-bin": "^0.24.2",
@@ -50,6 +51,7 @@
     "power-assert": "^1.4.1",
     "rimraf": "^2.5.2",
     "rollup": "^0.26.3",
+    "rollup-plugin-babel": "^2.4.0",
     "rollup-plugin-commonjs": "^2.2.1",
     "rollup-plugin-node-resolve": "^1.5.0",
     "uglify-js": "^2.6.2"


### PR DESCRIPTION
After cloning the repo and running `npm install`, I found I needed to install `rollup-plugin-babel` and `babel-preset-es2015-rollup` in order for `npm run build` to succeed.