### PR TITLE
chore(): fix for conflicting babel configurations causing tests to fail

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    "es2015-rollup"
+    "es2015"
   ],
   "plugins": [
     "syntax-flow",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build-dist": "mkdirp dist && rollup -c",
     "build": "npm run build-dist && uglifyjs dist/most-subject.js -o dist/most-subject.min.js",
     "lint": "eslint src/ && flow",
-    "mocha": "mocha --compilers js:babel-core/register",
+    "mocha": "mocha -r babel-register",
     "test": "npm run lint && npm run mocha",
     "docs": "rimraf docs && mkdirp docs && documentation build -f 'html' -g -o docs/ src/*.js",
     "preversion": "npm run build",
@@ -31,9 +31,6 @@
     "url": "https://github.com/tylors/most-subject/issues"
   },
   "homepage": "https://github.com/tylors/most-subject#readme",
-  "browserify-shim": {
-    "most": "global:most"
-  },
   "devDependencies": {
     "@most/eslint-config-most": "^1.0.2",
     "babel-cli": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "babel-plugin-transform-flow-strip-types": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-es2015-rollup": "^1.1.1",
+    "babel-register": "^6.8.0",
     "documentation": "^4.0.0-beta2",
     "eslint": "^2.10.1",
     "flow-bin": "^0.24.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,11 @@ export default {
   entry: 'src/index.js',
   format: 'umd',
   plugins: [
-    babel()
+    babel({
+      babelrc: false,
+      presets: ['es2015-rollup'],
+      plugins: ['syntax-flow', 'transform-flow-strip-types']
+    })
   ],
   sourceMap: true,
   globals: {


### PR DESCRIPTION
The .babelrc was conflicting between the tests and the rollup configuration. This sets up the rollup config to ignore the babelrc and use it's own local configuration.