### PR TITLE
Support multiple run/dispose cycles for sources

### DIFF
--- a/src/SubjectSource.ts
+++ b/src/SubjectSource.ts
@@ -14,11 +14,14 @@ export interface SubjectSource<T> extends Source<T> {
 export class BasicSubjectSource<T> implements SubjectSource<T> {
   protected scheduler: Scheduler = defaultScheduler;
   protected sinks: Sink<T>[] = [];
-  protected active: boolean = true;
+  protected active: boolean = false;
 
   run (sink: Sink<T>, scheduler: Scheduler): Disposable<T> {
     const n = this.add(sink);
-    if (n === 1) this.scheduler = scheduler;
+    if (n === 1) {
+      this.scheduler = scheduler;
+      this.active = true;
+    }
     return new SubjectDisposable<T>(this, sink);
   }
 
@@ -48,14 +51,14 @@ export class BasicSubjectSource<T> implements SubjectSource<T> {
   error (err: Error): void {
     if (!this.active || this.scheduler === void 0) return;
 
-    this.active = false;
+    this._dispose();
     this._error(this.scheduler.now(), err);
   }
 
   complete (value?: T): void {
     if (!this.active || this.scheduler === void 0) return;
 
-    this.active = false;
+    this._dispose();
     this._complete(this.scheduler.now(), value);
   }
 

--- a/test/holdSubject.js
+++ b/test/holdSubject.js
@@ -25,6 +25,9 @@ describe('holdSubject', () => {
   it('should allow for adjusting bufferSize of stream', () => {
     const stream = holdSubject(3)
 
+    // Add an observer so the stream begins buffering events
+    stream.observe(() => {})
+
     stream.next(1)
     stream.next(2)
     stream.next(3)

--- a/test/subject.js
+++ b/test/subject.js
@@ -86,5 +86,25 @@ describe('subject()', () => {
       stream.complete()
       stream.next(1)
     })
+
+    it('should support transient use as a signal stream', done => {
+      const stream = subject()
+      const signalStream = subject()
+
+      const observeUntilSignal = () => stream
+        .until(signalStream)
+        .observe(() => {})
+
+      observeUntilSignal()
+        .then(() => {
+          const promiseToEnd = observeUntilSignal()
+          signalStream.next()
+          return promiseToEnd
+        })
+        .then(done)
+        .catch(assert.fail)
+
+      signalStream.next()
+    })
   })
 })

--- a/test/subject.js
+++ b/test/subject.js
@@ -75,7 +75,7 @@ describe('subject()', () => {
       stream.complete()
     })
 
-    it('should not allow events after end', done => {
+    it('should not notify existing observers after end', done => {
       const stream = subject()
 
       stream
@@ -85,6 +85,53 @@ describe('subject()', () => {
 
       stream.complete()
       stream.next(1)
+    })
+
+    it('should not notify existing observers after error', done => {
+      const stream = subject()
+
+      stream
+        .forEach(assert.fail)
+        .then(done, () => done())
+        .catch(assert.fail)
+
+      stream.error(new Error())
+      stream.next(1)
+    })
+
+    it('should allow new observers after end', done => {
+      const stream = subject()
+
+      stream.complete()
+
+      stream
+        .reduce((x, y) => x.concat(y), [])
+        .then(x => assert.deepEqual(x, [1, 2, 3]))
+        .then(done)
+
+      stream.next(1)
+      stream.next(2)
+      stream.next(3)
+
+      stream.complete()
+    })
+
+
+    it('should allow new observers after error', done => {
+      const stream = subject()
+
+      stream.error(new Error())
+
+      stream
+        .reduce((x, y) => x.concat(y), [])
+        .then(x => assert.deepEqual(x, [1, 2, 3]))
+        .then(done)
+
+      stream.next(1)
+      stream.next(2)
+      stream.next(3)
+
+      stream.complete()
     })
 
     it('should support transient use as a signal stream', done => {


### PR DESCRIPTION
Hi @TylorS,

I am encountering a problem using a subject as a signal for `most.until`. It works the first time, but if I try using the same subject later with `until`, `until` never receives a signal because the subject no longer emits events.

The reason appears to be that a source may be run and disposed multiple times in its lifetime, but BasicSubjectSource only expects to be disposed once. This is a PR to fix that issue.

To see how a source may be run and disposed multiple times, you can examine `UpperBound`, which is used to implement `until`, [calling run on the signal](https://github.com/cujojs/most/blob/2a53262f2b316f333ca85566daaa78bf40eeae45/lib/combinator/timeslice.js#L99) (a source) and [later disposing it](https://github.com/cujojs/most/blob/2a53262f2b316f333ca85566daaa78bf40eeae45/lib/combinator/timeslice.js#L113).

Here is a simplified example where I'm triggering the issue:
```javascript
// mouseDown$, mouseMove$, and mouseUp$ are subjects used to relay DOM events
mouseDown$.chain(
  mouseDownEvent => mouseMove$.until(mouseUp$).map(...)
)
.observe(...)
```
This works the first time `mouseUp$` signals. After that, `mouseUp$` has been disposed, which permanently marks the subject inactive and blocks further events from being relayed. When another `mouseDown$` event arrives, `mouseUp$` is passed to `until` and is `run` but never marks itself as active which would allow events to be relayed again.

I don't love my wording in the commit messages or the name of the new test, but that is the best I came up with tonight. Any suggestions for those would be appreciated. :)